### PR TITLE
Do not subtract offset from MAX_GPU_CLOCK

### DIFF
--- a/gpu_undervolt.sh
+++ b/gpu_undervolt.sh
@@ -182,7 +182,7 @@ adjust_gpu() {
     offset=$3
 
     nvidia-smi -i $gpu -pm 1
-    nvidia-smi -i $gpu -lgc 0,$((gpu_high - offset))
+    nvidia-smi -i $gpu -lgc 0,$gpu_high
 
     run_nvidia_settings \
      -a [gpu:$gpu]/GPUGraphicsClockOffsetAllPerformanceLevels=$offset


### PR DESCRIPTION
I still can't see why do this.
You should be able to set one of the frequencies from the reported list after doing
`nvidia-smi -i 0 --query-supported-clocks=gr,mem --format=csv`
and unnecessary math operations mess with those values.